### PR TITLE
Issue-4 - Remove footer site name link.

### DIFF
--- a/templates/footer--ec-corporate.tpl.php
+++ b/templates/footer--ec-corporate.tpl.php
@@ -11,7 +11,7 @@
       <div class="ecl-row">
         <div class="ecl-col-sm ecl-footer__column">
           <h4 class="ecl-h4">
-            <a class="ecl-link ecl-footer__link" href="#"><?php print $site_name; ?></a>
+            <?php print $site_name; ?>
           </h4>
         </div>
         <div class="ecl-col-sm ecl-footer__column">


### PR DESCRIPTION
Hi @julien- We had some remarks on the "site name" link of the footer pointing to #
In comparison with the footer component of ECL, this one has no link on the "site name" in the footer:
https://ec-europa.github.io/europa-component-library/ec/components/detail/ec-component-footer 
I suggest to remove the link, in advance thank you for your feedback.